### PR TITLE
Fix CI error

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -47,6 +47,7 @@ install_version() {
 		local bison_brew_path
 		bison_brew_path="$(brew --prefix bison)/bin"
 		export PATH="$bison_brew_path:$PATH"
+		export CXXFLAGS="-Wno-inconsistent-missing-override"
 		local bison_version
 		if ! type "automake" >/dev/null 2>&1; then
 			fail "Thrift requires automake"


### PR DESCRIPTION
Suppress warning "verrides a member function but is not marked 'override'" to avoid build error using clang on MacOS

FYI: https://github.com/alisaifee/asdf-thrift/runs/6823803209?check_suite_focus=true#step:4:115
```sh
  In file included from src/thrift/generate/t_netstd_generator.cc:38:
  ./src/thrift/generate/t_netstd_generator.h:72:8: error: 'init_generator' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
    void init_generator();
         ^
  ./src/thrift/generate/t_generator.h:141:16: note: overridden virtual function is here
    virtual void init_generator() {}
                 ^
  In file included from src/thrift/generate/t_netstd_generator.cc:38:
  ./src/thrift/generate/t_netstd_generator.h:73:8: error: 'close_generator' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
    void close_generator();
         ^
```